### PR TITLE
Add --absolute_depth flag

### DIFF
--- a/run_monodepth.py
+++ b/run_monodepth.py
@@ -171,7 +171,7 @@ def run(input_path, output_path, model_path, model_type="dpt_hybrid", optimize=T
         filename = os.path.join(
             output_path, os.path.splitext(os.path.basename(img_name))[0]
         )
-        util.io.write_depth(filename, prediction, bits=2)
+        util.io.write_depth(filename, prediction, bits=2, absolute_depth=args.absolute_depth)
 
     print("finished")
 
@@ -202,12 +202,14 @@ if __name__ == "__main__":
     )
 
     parser.add_argument("--kitti_crop", dest="kitti_crop", action="store_true")
+    parser.add_argument("--absolute_depth", dest="absolute_depth", action="store_true")
 
     parser.add_argument("--optimize", dest="optimize", action="store_true")
     parser.add_argument("--no-optimize", dest="optimize", action="store_false")
 
     parser.set_defaults(optimize=True)
     parser.set_defaults(kitti_crop=False)
+    parser.set_defaults(absolute_depth=False)
 
     args = parser.parse_args()
 

--- a/util/io.py
+++ b/util/io.py
@@ -168,7 +168,7 @@ def resize_depth(depth, width, height):
     return depth_resized
 
 
-def write_depth(path, depth, bits=1):
+def write_depth(path, depth, bits=1, absolute_depth=False):
     """Write depth map to pfm and png file.
 
     Args:
@@ -177,20 +177,23 @@ def write_depth(path, depth, bits=1):
     """
     write_pfm(path + ".pfm", depth.astype(np.float32))
 
-    depth_min = depth.min()
-    depth_max = depth.max()
-
-    max_val = (2 ** (8 * bits)) - 1
-
-    if depth_max - depth_min > np.finfo("float").eps:
-        out = max_val * (depth - depth_min) / (depth_max - depth_min)
+    if absolute_depth:
+        out = depth
     else:
-        out = np.zeros(depth.shape, dtype=depth.dtype)
+        depth_min = depth.min()
+        depth_max = depth.max()
+
+        max_val = (2 ** (8 * bits)) - 1
+
+        if depth_max - depth_min > np.finfo("float").eps:
+            out = max_val * (depth - depth_min) / (depth_max - depth_min)
+        else:
+            out = np.zeros(depth.shape, dtype=depth.dtype)
 
     if bits == 1:
-        cv2.imwrite(path + ".png", out.astype("uint8"))
+        cv2.imwrite(path + ".png", out.astype("uint8"), [cv2.IMWRITE_PNG_COMPRESSION, 0])
     elif bits == 2:
-        cv2.imwrite(path + ".png", out.astype("uint16"))
+        cv2.imwrite(path + ".png", out.astype("uint16"), [cv2.IMWRITE_PNG_COMPRESSION, 0])
 
     return
 


### PR DESCRIPTION
I added the missing flag `--absolute_depth` for evaluating on Kitti and NYU datasets, to solve the issue https://github.com/intel-isl/DPT/issues/31

### Kitti
* Remove images from `/input/` and `/output_monodepth/` folders
* Download `kitti_eval_dataset.zip` https://drive.google.com/file/d/1GbfMGuwg2VS06Vl75-_tB5FDj9EOrjl0/view?usp=sharing and unzip it in the `/input/` folder (or follow this repository https://github.com/cogaplex-bts/bts to get RGB and Depth images from list [eigen_test_files_with_gt.txt](https://github.com/cogaplex-bts/bts/blob/master/train_test_inputs/eigen_test_files_with_gt.txt) )
* Download [dpt_hybrid_kitti-cb926ef4.pt](https://github.com/intel-isl/DPT/releases/download/1_0/dpt_hybrid_kitti-cb926ef4.pt) model and place it in the `/weights/` folder
* Download [eval_with_pngs.py](https://raw.githubusercontent.com/cogaplex-bts/bts/5a55542ebbe849eb85b5ce9592365225b93d8b28/utils/eval_with_pngs.py) in the root folder
* `python run_monodepth.py --model_type dpt_hybrid_kitti --kitti_crop --absolute_depth`
* `python ./eval_with_pngs.py --pred_path ./output_monodepth/ --gt_path ./input/gt/ --dataset kitti --min_depth_eval 1e-3 --max_depth_eval 80 --garg_crop --do_kb_crop`

Result:
```
Evaluating 697 files
GT files reading done
45 GT files missing
Computing errors
     d1,      d2,      d3,  AbsRel,   SqRel,    RMSE, RMSElog,   SILog,   log10
  0.959,   0.995,   0.999,   0.062,   0.222,   2.575,   0.092,   8.282,   0.027
Done.
```

----

### NYUv2
* Remove images from `/input/` and `/output_monodepth/` folders
* Download `nyu_eval_dataset.zip` https://drive.google.com/file/d/1b37uu-bqTZcSwokGkHIOEXuuBdfo80HI/view?usp=sharing and unzip it in the `/input/` folder (or follow this repository https://github.com/cogaplex-bts/bts to get RGB and Depth images from list [nyudepthv2_test_files_with_gt.txt](https://github.com/cogaplex-bts/bts/blob/master/train_test_inputs/nyudepthv2_test_files_with_gt.txt) )
* Download [dpt_hybrid_nyu-2ce69ec7.pt](https://github.com/intel-isl/DPT/releases/download/1_0/dpt_hybrid_nyu-2ce69ec7.pt) model (**or a new model** that is fine-tuned with slightly different hyperparameters [dpt_hybrid_nyu_new-217f207d.pt](https://drive.google.com/file/d/1Nxv2OiqhAMosBL2a3pflamTW39dMjaSp/view?usp=sharing)  ) and place it in the `/weights/` folder
* Download [eval_with_pngs.py](https://raw.githubusercontent.com/cogaplex-bts/bts/5a55542ebbe849eb85b5ce9592365225b93d8b28/utils/eval_with_pngs.py) in the root folder
* `python run_monodepth.py --model_type dpt_hybrid_nyu --absolute_depth`
(or **for new model** `python run_monodepth.py --model_type dpt_hybrid_nyu --absolute_depth --model_weights weights/dpt_hybrid_nyu_new-217f207d.pt` )
* `python ./eval_with_pngs.py --pred_path ./output_monodepth/ --gt_path ./input/gt/ --dataset nyu --max_depth_eval 10`

Result (new model):
```
Evaluating 654 files
GT files reading done
0 GT files missing
Computing errors
     d1,      d2,      d3,  AbsRel,   SqRel,    RMSE, RMSElog,   SILog,   log10
  0.904,   0.988,   0.998,   0.110,   0.055,   0.358,   0.129,   9.481,   0.045
Done.
```

Result (old model):
```
Evaluating 654 files
GT files reading done
0 GT files missing
Computing errors
     d1,      d2,      d3,  AbsRel,   SqRel,    RMSE, RMSElog,   SILog,   log10
  0.903,   0.988,   0.998,   0.110,   0.054,   0.357,   0.130,   9.575,   0.045
Done.
```

